### PR TITLE
Fix the training and testing data preprocess.

### DIFF
--- a/Data Play.ipynb
+++ b/Data Play.ipynb
@@ -905,7 +905,7 @@
     "print(X.shape)\n",
     "X[:,:,0] = X[:,:,0] / 720 # I think the dimensions are 1280 x 720 ?\n",
     "X[:,:,1] = X[:,:,1] / 1280  # let's see?\n",
-    "X = X[:,:,1:]\n",
+    "X = X[:,:,:2]\n",
     "print(X.shape)\n",
     "X = X.reshape(56, 50)      # we got rid of confidence percentage\n",
     "print(X.shape)"
@@ -2493,7 +2493,7 @@
     "print(X1.shape)\n",
     "X1[:,:,0] = X1[:,:,0] / 720 # I think the dimensions are 1280 x 720 ?\n",
     "X1[:,:,1] = X1[:,:,1] / 1280  # let's see?\n",
-    "X1 = X1[:,:,1:]\n",
+    "X1 = X1[:,:,:2]\n",
     "print(X1.shape)\n",
     "X1 = X1.reshape(len(X1), 50)      # we got rid of confidence percentage\n",
     "print(X1.shape)"
@@ -6844,7 +6844,7 @@
     "dabDataset = np.load('data/test-dabs.npy')\n",
     "dabDataset[:,:,0] = dabDataset[:,:,0] / 720 # I think the dimensions are 1280 x 720 ?\n",
     "dabDataset[:,:,1] = dabDataset[:,:,1] / 1280  # let's see?\n",
-    "dabDataset = dabDataset[:,:,1:]\n",
+    "dabDataset = dabDataset[:,:,:2]\n",
     "dabDataset = dabDataset.reshape(len(dabDataset), 50)\n",
     "modello.predict_classes(dabDataset)"
    ]


### PR DESCRIPTION
    In the 'Cleaning up data further', 'Adding More Data and Beginning Data Augmentation' and the and blocks, we want the position information but not the confidence. 
    Therefore, the original code `X = X[:,:,1:]` to remove the confidence column.
    However, the format of the original data is [x, y, confidence]. (refer to https://github.com/CMU-Perceptual-Computing-Lab/openpose/blob/master/doc/output.md#output-format)

    Thus, the code has modified to `X = X[:,:,:2]`.